### PR TITLE
Add convenience initializer for Store without dependencies

### DIFF
--- a/Sources/UnidirectionalFlow/Store.swift
+++ b/Sources/UnidirectionalFlow/Store.swift
@@ -50,7 +50,6 @@ extension Store {
         let derived = Store<DerivedState, DerivedAction, Void>(
             initialState: deriveState(state),
             reducer: IdentityReducer(),
-            dependencies: (),
             middlewares: [
                 SendableMiddleware { _, action, _ in
                     await self.send(deriveAction(action))
@@ -78,6 +77,21 @@ extension Store {
         .init(
             get: { extract(self.state) },
             set: { newValue in Task { await self.send(embed(newValue)) } }
+        )
+    }
+}
+
+extension Store {
+    public convenience init(
+        initialState state: State,
+        reducer: some Reducer<State, Action>,
+        middlewares: some Collection<any Middleware<State, Action, Void>>
+    ) where Dependencies == Void {
+        self.init(
+            initialState: state,
+            reducer: reducer,
+            dependencies: (),
+            middlewares: middlewares
         )
     }
 }

--- a/Tests/UnidirectionalFlowTests/StoreTests.swift
+++ b/Tests/UnidirectionalFlowTests/StoreTests.swift
@@ -51,7 +51,6 @@ import XCTest
         let system = Store<State, Action, Void>(
             initialState: .init(),
             reducer: TestReducer(),
-            dependencies: (),
             middlewares: [TestMiddleware()]
         )
         
@@ -66,7 +65,6 @@ import XCTest
         let system = Store<State, Action, Void>(
             initialState: .init(),
             reducer: TestReducer(),
-            dependencies: (),
             middlewares: [TestMiddleware()]
         )
         
@@ -81,7 +79,6 @@ import XCTest
         let system = Store<State, Action, Void>(
             initialState: .init(),
             reducer: TestReducer(),
-            dependencies: (),
             middlewares: [TestMiddleware()]
         )
         
@@ -97,7 +94,6 @@ import XCTest
         let system = Store<State, Action, Void>(
             initialState: .init(),
             reducer: TestReducer(),
-            dependencies: (),
             middlewares: [TestMiddleware()]
         )
         
@@ -149,7 +145,6 @@ import XCTest
         let system = Store<State, Action, Void>(
             initialState: .init(),
             reducer: TestReducer(),
-            dependencies: (),
             middlewares: [TestMiddleware()]
         )
         


### PR DESCRIPTION
This initializer allows for creating a Store without explicitly passing () for the dependencies parameter if not using any dependencies.