### PR TITLE
Integrate publishers into store

### DIFF
--- a/Sources/Example/GithubApp.swift
+++ b/Sources/Example/GithubApp.swift
@@ -83,7 +83,8 @@ struct SearchContainerView: View {
     @StateObject private var store = SearchStore(
         initialState: .init(),
         reducer: SearchReducer(),
-        middlewares: [SearchMiddleware(dependencies: .production)]
+        middlewares: [SearchMiddleware(dependencies: .production)],
+        publishers: []
     )
     @State private var query = ""
     

--- a/Sources/UnidirectionalFlow/Store.swift
+++ b/Sources/UnidirectionalFlow/Store.swift
@@ -61,18 +61,16 @@ import Combine
 
 extension Store {
     /// Use this method to create another `Store` deriving from the current one.
-    public func derived<DerivedState: Equatable, DerivedAction>(
+    public func derived<DerivedState: Equatable, DerivedAction: Equatable>(
         deriveState: @escaping (State) -> DerivedState,
-        deriveAction: @escaping (DerivedAction) -> Action?
+        deriveAction: @escaping (DerivedAction) -> Action
     ) -> Store<DerivedState, DerivedAction> {
         let derived = Store<DerivedState, DerivedAction>(
             initialState: deriveState(state),
             reducer: IdentityReducer(),
             middlewares: [
                 SendableMiddleware { _, action in
-                    if let derivedAction = deriveAction(action) {
-                        await self.send(derivedAction)
-                    }
+                    await self.send(deriveAction(action))
                     return nil
                 }
             ],

--- a/Sources/UnidirectionalFlow/Store.swift
+++ b/Sources/UnidirectionalFlow/Store.swift
@@ -27,7 +27,6 @@ import Combine
         self.reducer = reducer
         self.middlewares = middlewares
 
-        // Subscribe to publishers and forward actions.
         for publisher in publishers {
             publisher.sink { action in
                 Task { await self.send(action) }

--- a/Sources/UnidirectionalFlow/Store.swift
+++ b/Sources/UnidirectionalFlow/Store.swift
@@ -50,16 +50,18 @@ import Foundation
 
 extension Store {
     /// Use this method to create another `Store` deriving from the current one.
-    public func derived<DerivedState: Equatable, DerivedAction: Equatable>(
+    public func derived<DerivedState: Equatable, DerivedAction>(
         deriveState: @escaping (State) -> DerivedState,
-        deriveAction: @escaping (DerivedAction) -> Action
+        deriveAction: @escaping (DerivedAction) -> Action?
     ) -> Store<DerivedState, DerivedAction> {
         let derived = Store<DerivedState, DerivedAction>(
             initialState: deriveState(state),
             reducer: IdentityReducer(),
             middlewares: [
                 SendableMiddleware { _, action in
-                    await self.send(deriveAction(action))
+                    if let derivedAction = deriveAction(action) {
+                        await self.send(derivedAction)
+                    }
                     return nil
                 }
             ]

--- a/Tests/UnidirectionalFlowTests/StoreTests.swift
+++ b/Tests/UnidirectionalFlowTests/StoreTests.swift
@@ -143,22 +143,6 @@ import XCTest
         
         XCTAssertEqual(store.counter, 2)
         XCTAssertEqual(derived.counter, 2)
-
-        let emptyAction: (Action) -> Action? = { _ in nil }
-        let derivedWithoutAction = store.derived(deriveState: { $0 }, deriveAction: emptyAction)
-
-        XCTAssertEqual(store.counter, 2)
-        XCTAssertEqual(derivedWithoutAction.counter, 2)
-
-        await derivedWithoutAction.send(.increment)
-
-        XCTAssertEqual(store.counter, 2)
-        XCTAssertEqual(derivedWithoutAction.counter, 2)
-
-        await store.send(.increment)
-
-        XCTAssertEqual(store.counter, 3)
-        XCTAssertEqual(derivedWithoutAction.counter, 3)
     }
     
     func testBinding() async {

--- a/Tests/UnidirectionalFlowTests/StoreTests.swift
+++ b/Tests/UnidirectionalFlowTests/StoreTests.swift
@@ -51,7 +51,8 @@ import XCTest
         let store = Store<State, Action>(
             initialState: .init(),
             reducer: TestReducer(),
-            middlewares: [TestMiddleware()]
+            middlewares: [TestMiddleware()],
+            publishers: []
         )
         
         XCTAssertEqual(store.counter, 0)
@@ -65,7 +66,8 @@ import XCTest
         let store = Store<State, Action>(
             initialState: .init(),
             reducer: TestReducer(),
-            middlewares: [TestMiddleware()]
+            middlewares: [TestMiddleware()],
+            publishers: []
         )
         
         XCTAssertEqual(store.counter, 0)
@@ -79,7 +81,8 @@ import XCTest
         let store = Store<State, Action>(
             initialState: .init(),
             reducer: TestReducer(),
-            middlewares: [TestMiddleware()]
+            middlewares: [TestMiddleware()],
+            publishers: []
         )
         
         XCTAssertEqual(store.counter, 0)
@@ -94,7 +97,8 @@ import XCTest
         let store = Store<State, Action>(
             initialState: .init(),
             reducer: TestReducer(),
-            middlewares: [TestMiddleware()]
+            middlewares: [TestMiddleware()],
+            publishers: []
         )
         
         let derived = store.derived(deriveState: { $0 }, deriveAction: { $0 } )
@@ -161,7 +165,8 @@ import XCTest
         let store = Store<State, Action>(
             initialState: .init(),
             reducer: TestReducer(),
-            middlewares: [TestMiddleware()]
+            middlewares: [TestMiddleware()],
+            publishers: []
         )
         
         let binding = store.binding(

--- a/Tests/UnidirectionalFlowTests/StoreTests.swift
+++ b/Tests/UnidirectionalFlowTests/StoreTests.swift
@@ -134,11 +134,27 @@ import XCTest
         
         XCTAssertEqual(store.counter, 3)
         XCTAssertEqual(derived.counter, 3)
-        
+
         await derived.send(.decrement)
         
         XCTAssertEqual(store.counter, 2)
         XCTAssertEqual(derived.counter, 2)
+
+        let emptyAction: (Action) -> Action? = { _ in nil }
+        let derivedWithoutAction = store.derived(deriveState: { $0 }, deriveAction: emptyAction)
+
+        XCTAssertEqual(store.counter, 2)
+        XCTAssertEqual(derivedWithoutAction.counter, 2)
+
+        await derivedWithoutAction.send(.increment)
+
+        XCTAssertEqual(store.counter, 2)
+        XCTAssertEqual(derivedWithoutAction.counter, 2)
+
+        await store.send(.increment)
+
+        XCTAssertEqual(store.counter, 3)
+        XCTAssertEqual(derivedWithoutAction.counter, 3)
     }
     
     func testBinding() async {


### PR DESCRIPTION
As discussed on [Mastodon](https://mastodon.social/@Mecid/110617640213656585) I found a way to integrate CoreData entity stores (as I call them so far) as suggested [here](https://ichi.pro/de/swiftui-und-coredata-auf-mvvm-weise-188670527930127) into the store via Combine publishers.

I use a singleton "entity store" per CoreData entity. When I set up the store I hand over one publisher per "entity store" mapping the CoreData changes of the entities to update actions for the store. This action typically has an array of the instances as payload:

`EntityStore.shared.instances.map { AppAction.entityAction(.updateEntity($0)) }`

Processing such an action in the according reducer would end up updating the composed state with the updated instances of that entity:

```
      case .updateEntity(let instances):
            state.instances = instances
```
 
Don't be confused by the different commits. I reverted the changes re: allowing empty actions for derived stores (I will consider you suggestion to this next) and renamed the branch from `development` to `integrate-pusblishers-into-store`.